### PR TITLE
Add swift-numerics for macOS toolchain compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
-        .package(url: "https://github.com/typesense/typesense-swift.git", from: "1.0.1")
+        .package(url: "https://github.com/typesense/typesense-swift.git", from: "1.0.1"),
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0")
     ],
     targets: [
         .target(
@@ -23,7 +24,8 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-                .product(name: "Typesense", package: "typesense-swift")
+                .product(name: "Typesense", package: "typesense-swift"),
+                .product(name: "Numerics", package: "swift-numerics")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- Adds swift-numerics dependency and links Numerics in the SemanticBrowser target to ensure _NumericsShims is available on macOS toolchains.
- No runtime or API changes; build-only change.
- Verified on macOS: swift build/test succeed.

## Testing
- `swift build -v`
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_b_68b039b4d9a4833387ae3e8321f797f7